### PR TITLE
Revert "Bump starlette from 0.17.1 to 0.18.0 in /server"

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -20,6 +20,6 @@ sniffio==1.2.0
 SQLAlchemy==1.4.31
 sqlalchemy2-stubs==0.0.2a19
 sqlmodel==0.0.6
-starlette==0.18.0
+starlette==0.17.1
 typing_extensions==4.0.1
 uvicorn==0.17.0.post1


### PR DESCRIPTION
Reverts rabinadk1/text-classification#21 because fastapi depends upon the previous version