### PR TITLE
Backend: implemented lru_cache with timeout

### DIFF
--- a/server/app/tweets_common/decorators.py
+++ b/server/app/tweets_common/decorators.py
@@ -1,0 +1,42 @@
+from functools import lru_cache, wraps
+from time import monotonic_ns
+
+from typing import Optional
+
+
+def timed_lru_cache(
+    _func=None, *, 
+    seconds: Optional[int] = 600, 
+    maxsize: Optional[int] = 128, 
+    typed: Optional[bool] = False
+):
+    """Extension of functools lru_cache with a timeout
+
+    Parameters:
+    seconds (int): Timeout in seconds to clear the WHOLE cache, default = 10 minutes
+    maxsize (int): Maximum Size of the Cache
+    typed (bool): Same value of different type will be a different entry
+
+    """
+
+    def wrapper_cache(f):
+        f = lru_cache(maxsize=maxsize, typed=typed)(f)
+        f.delta = seconds * 10 ** 9
+        f.expiration = monotonic_ns() + f.delta
+
+        @wraps(f)
+        def wrapped_f(*args, **kwargs):
+            if monotonic_ns() >= f.expiration:
+                f.cache_clear()
+                f.expiration = monotonic_ns() + f.delta
+            return f(*args, **kwargs)
+
+        wrapped_f.cache_info = f.cache_info
+        wrapped_f.cache_clear = f.cache_clear
+        return wrapped_f
+
+    # To allow decorator to be used without arguments
+    if _func is None:
+        return wrapper_cache
+    else:
+        return wrapper_cache(_func)

--- a/server/app/tweets_common/routes.py
+++ b/server/app/tweets_common/routes.py
@@ -2,7 +2,6 @@ from datetime import date
 from typing import List, Optional
 
 from fastapi import Depends, Query
-from nltk import FreqDist
 from sqlmodel import Session, select, union_all
 
 from ..database import get_session
@@ -10,7 +9,7 @@ from . import router
 from .helper_functions import get_filtered_selection
 from .models import PseudoTweet, Topics, Tweet
 from .types import Month
-from .word_cloud_helper import word_tokenize_nepali
+from .word_cloud_helper import get_word_count_distribution
 
 
 @router.get("/")
@@ -35,14 +34,7 @@ def get_word_cloud(
     # Manually selected the text here, need to change if needed
     combined_tweets = session.exec(select(combined_model.text)).all()
 
-    # It is a generator of tuples
-    two_dimensional_tokens = map(word_tokenize_nepali, combined_tweets)
+    # change list of tweets to tuple to allow caching
+    word_freq = get_word_count_distribution(tuple(combined_tweets))
 
-    flat_tokens: List[str] = []
-
-    for token in two_dimensional_tokens:
-        flat_tokens.extend(token)
-
-    word_freq = FreqDist(flat_tokens)
-
-    return word_freq.most_common(100)
+    return word_freq


### PR DESCRIPTION
- Implemented a `timed_lru_cache` decorator which is an extension of the `functools.lru_cache` with a timeout parameter
- Used the `timed_lru_cache` decorator in the `get_word_count_distribution` function
- changed the `get_word_cloud` route as per the caching requirements 